### PR TITLE
Cosmetics

### DIFF
--- a/bin/_mb.bat
+++ b/bin/_mb.bat
@@ -109,6 +109,5 @@ goto :eof
 	if "%PYBLISH_LITE%"=="" echo   - %%PYBLISH_LITE%%
 	if "%PYBLISH_QML%"=="" echo   - %%PYBLISH_QML%%
 	if "%MINDBENDER_CORE%"=="" echo   - %%MINDBENDER_CORE%%
-	if "%PYBLISH_USERNAME%"=="" echo   - %%PYBLISH_USERNAME%%
 
 	exit /b

--- a/mindbender/maya/lib.py
+++ b/mindbender/maya/lib.py
@@ -393,8 +393,8 @@ def apply_shaders(relationships):
     """
 
     for shader, ids in relationships.items():
-        print("Looking for '*:%s'.." % shader)
-        shader = next(iter(cmds.ls("*:" + shader)), None)
+        print("Looking for '%s'.." % shader)
+        shader = next(iter(cmds.ls(shader)), None)
         assert shader, "Associated shader not part of asset, this is a bug"
 
         for id_ in ids:

--- a/mindbender/maya/loaders/mindbender_look.py
+++ b/mindbender/maya/loaders/mindbender_look.py
@@ -51,6 +51,13 @@ class LookLoader(api.Loader):
             with open(path) as f:
                 relationships = json.load(f)
 
+            # Append namespace to shader group identifier.
+            # E.g. `blinn1SG` -> `Bruce_:blinn1SG`
+            relationships = {
+                "%s:%s" % (namespace, shader): relationships[shader]
+                for shader in relationships
+            }
+
             maya.apply_shaders(relationships)
 
         return nodes

--- a/mindbender/maya/pythonpath/userSetup.py
+++ b/mindbender/maya/pythonpath/userSetup.py
@@ -26,8 +26,8 @@ def setup():
         "60": "ntscf"
     }.get(os.getenv("MINDBENDER_FPS"), "pal")  # Default to "pal"
 
-    EDIT_IN = os.getenv("MINDBENDER_EDIT_IN") or 1000
-    EDIT_OUT = os.getenv("MINDBENDER_EDIT_OUT") or 1200
+    EDIT_IN = os.getenv("MINDBENDER_EDIT_IN") or 101
+    EDIT_OUT = os.getenv("MINDBENDER_EDIT_OUT") or 201
     RESOLUTION_WIDTH = os.getenv("MINDBENDER_RESOLUTION_WIDTH") or 1920
     RESOLUTION_HEIGHT = os.getenv("MINDBENDER_RESOLUTION_HEIGHT") or 1080
 

--- a/mindbender/maya/pythonpath/userSetup.py
+++ b/mindbender/maya/pythonpath/userSetup.py
@@ -5,33 +5,6 @@ from maya import cmds
 import os
 
 
-def mayafpsconverter(fps):
-    ERRORSTRING = "MINDBENDER_FPS variable has letters or bad value check the bat file"
-    """This checks to see that the value in MINDBENDER_FPS.string
-    doesn't conttain any letters
-    exampel "12" is valid
-    exampel "1a2" is invalid
-    """
-    if str(fps).isdigit() is False:
-        cmds.confirmDialog(title="Enviroment variable error",
-                           message=ERRORSTRING,
-                           button="",
-                           defaultButton="",
-                           cancelButton="",
-                           dismissString="")
-        return ""
-    return {
-        "15": "game",
-        "24": "film",
-        "25": "pal",
-        "30": "ntsc",
-        "48": "show",
-        "50": "palf",
-        "60": "ntscf",
-        None: "",
-        "": "", }.get(fps, fps + "fps")
-
-
 def setup():
     assert __import__("pyblish_maya").is_setup(), (
         "mindbender-core depends on pyblish_maya which has not "
@@ -43,18 +16,26 @@ def setup():
     from mindbender import api, maya
     api.install(maya)
 
-    MINDBENDER_FPS = os.getenv("MINDBENDER_FPS")
-    MINDBENDER_EDIT_IN = os.getenv("MINDBENDER_EDIT_IN")
-    MINDBENDER_EDIT_OUT = os.getenv("MINDBENDER_EDIT_OUT")
-    MINDBENDER_RESOLUTION_WIDTH = os.getenv("MINDBENDER_RESOLUTION_WIDTH")
-    MINDBENDER_RESOLUTION_HEIGHT = os.getenv("MINDBENDER_RESOLUTION_HEIGHT")
+    FPS = {
+        "15": "game",
+        "24": "film",
+        "25": "pal",
+        "30": "ntsc",
+        "48": "show",
+        "50": "palf",
+        "60": "ntscf"
+    }.get(os.getenv("MINDBENDER_FPS"), "pal")  # Default to "pal"
 
-    if MINDBENDER_FPS is not None:
-        cmds.currentUnit(time=(mayafpsconverter(MINDBENDER_FPS)))
-    if MINDBENDER_EDIT_IN is not None:
-        cmds.playbackOptions(animationStartTime=MINDBENDER_EDIT_IN)
-    if MINDBENDER_EDIT_OUT is not None:
-        cmds.playbackOptions(animationEndTime=MINDBENDER_EDIT_OUT)
+    EDIT_IN = os.getenv("MINDBENDER_EDIT_IN") or 1000
+    EDIT_OUT = os.getenv("MINDBENDER_EDIT_OUT") or 1200
+    RESOLUTION_WIDTH = os.getenv("MINDBENDER_RESOLUTION_WIDTH") or 1920
+    RESOLUTION_HEIGHT = os.getenv("MINDBENDER_RESOLUTION_HEIGHT") or 1080
+
+    cmds.setAttr("defaultResolution.width", RESOLUTION_WIDTH)
+    cmds.setAttr("defaultResolution.height", RESOLUTION_HEIGHT)
+    cmds.currentUnit(time=FPS)
+    cmds.playbackOptions(animationStartTime=EDIT_IN)
+    cmds.playbackOptions(animationEndTime=EDIT_OUT)
 
 
 # Allow time for dependencies (e.g. pyblish-maya)

--- a/mindbender/plugins/validate_file_saved.py
+++ b/mindbender/plugins/validate_file_saved.py
@@ -28,7 +28,7 @@ class ValidateCurrentSaveFile(pyblish.api.ContextPlugin):
             ".",
             # An unsaved file in Nuke has this value.
             "Root",
-            # An unsaved file in Houdini has one of these values.
+            # An unsaved file in Houdini has this value.
             "untitled.hip"
         ]
 

--- a/mindbender/tools/manager/app.py
+++ b/mindbender/tools/manager/app.py
@@ -276,7 +276,8 @@ class Window(QtWidgets.QDialog):
         for container in self.ls():
             has["containers"] = True
 
-            item = QtWidgets.QListWidgetItem(container["subset"])
+            name = "{name}\t({subset})".format(**container)
+            item = QtWidgets.QListWidgetItem(name)
             item.setData(QtCore.Qt.ItemIsEnabled, True)
             item.setData(ContainerRole, container)
             containers_model.addItem(item)

--- a/template/AssetName.bat
+++ b/template/AssetName.bat
@@ -10,9 +10,6 @@ call _mkasset %~n0 %~dp0%
 :: Additional variables
 :: ------------------
 
-:: (str, optional): This variable is ??????, for example "prop, char"
-set MINDBENDER_OBJECT3D=
-
 :: (int, optional): In-time used in the edit
 set MINDBENDER_EDIT_IN=101
 

--- a/template/AssetName.bat
+++ b/template/AssetName.bat
@@ -6,13 +6,15 @@
 @echo off
 call _mkasset %~n0 %~dp0%
 
-:: Following is the variables that can be set in the bat
-::
-:: They are default set to "nothing"
-:: leave them be if you dont have the info for them and return to them later.
-:: setOBJECT expects a string like "prop, char"
-:: MINDBENDER_EDIT_IN and MINDBENDER_EDIT_OUT sets the assets time in and out for the edit. 
-:: These should not be set for assets, use this options for shots
-set OBJECT3D=
-set MINDBENDER_EDIT_IN=
-set MINDBENDER_EDIT_OUT=
+:: ------------------
+:: Additional variables
+:: ------------------
+
+:: (str, optional): This variable is ??????, for example "prop, char"
+set MINDBENDER_OBJECT3D=
+
+:: (int, optional): In-time used in the edit
+set MINDBENDER_EDIT_IN=1000
+
+:: (int, optional): Out-time used in the edit
+set MINDBENDER_EDIT_OUT=1200

--- a/template/AssetName.bat
+++ b/template/AssetName.bat
@@ -14,7 +14,7 @@ call _mkasset %~n0 %~dp0%
 set MINDBENDER_OBJECT3D=
 
 :: (int, optional): In-time used in the edit
-set MINDBENDER_EDIT_IN=1000
+set MINDBENDER_EDIT_IN=101
 
 :: (int, optional): Out-time used in the edit
-set MINDBENDER_EDIT_OUT=1200
+set MINDBENDER_EDIT_OUT=201

--- a/template/ProjectName.bat
+++ b/template/ProjectName.bat
@@ -7,9 +7,15 @@
 @echo off
 call _mkproject %~dp0 %~n0 %1
 
-:: Following is the variables that can be set in the bat
-::
-set MINDBENDER_ASSETCATEGORY=
-set MINDBENDER_FPS=
-set MINDBENDER_RESOLUTION_WIDTH=
-set MINDBENDER_RESOLUTION_HEIGHT=
+:: --------------------
+:: Additional Variables
+:: --------------------
+
+:: (int): Current frames per second for the project
+set MINDBENDER_FPS=25
+
+:: (str): Render resolution width
+set MINDBENDER_RESOLUTION_WIDTH=1920
+
+:: (str): Render resolution height
+set MINDBENDER_RESOLUTION_HEIGHT=1080


### PR DESCRIPTION
Hi @LegacyID1991,

I've made a few tweaks to your latest PR, code convention and documentation. But primarily I've refactored userSetup.py, as it seems no other value than those left are possible.

Before, the default value was `fps + "fps"` which would have resulted in `17` becoming `17fps`. But Maya [can't take that value](http://help.autodesk.com/cloudhelp/2015/ENU/Maya-Tech-Docs/CommandsPython/currentUnit.html). Because of that, I also removed the check, and instead defaulted to `"pal"` if no valid value was found.

I removed the interactive dialog box warning against an invalid FPS as well, because (1) better not assume too much until you've experienced a problem with it first hand and (2) interactive errors should not happen in userSetup.py, because userSetup.py should never fail. If it fails, Maya may become unstable simply because we can't be sure about at which point in the userSetup it failed.

If you take a look at the code now, it should be both shorter and failsafe. Any errors coming in from the environment are gracefully handled and falls back to a default value.