### PR TITLE
Editorial control before publish

### DIFF
--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -37,9 +37,12 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         if scene_fps is None:
             scene_fps = "New Value"
 
-        valid_fps = context.data.get("project_fps")
-        valid_edit_in = context.data.get("project_edit_in")
-        valid_edit_out = context.data.get("project_edit_out")
+        valid_fps = context.data.get("projectFPS")
+        valid_edit_in = context.data.get("projectEditIn")
+        valid_edit_out = context.data.get("projectEditOut")
+
+        if valid_fps is None:
+            return None
 
         assert valid_fps == scene_fps, (
             "The FPS is set to %sfps and not to %sfps"

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -34,15 +34,17 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         if scene_fps is None:
             scene_fps = "a strange "
 
-        if "environment" not in context.data:
-            self.log.debug(" environment no set")
-            return
-
         env = context.data.get("environment", dict())
 
-        valid_fps = env.get("mindbenderFps", 0)
-        valid_edit_in = env.get("mindbenderEditIn", 0)
-        valid_edit_out = env.get("mindbenderEditOut", 0)
+        valid_fps = env.get("mindbenderFps")
+        valid_edit_in = env.get("mindbenderEditIn")
+        valid_edit_out = env.get("mindbenderEditOut")
+
+        skip_on_none = [valid_fps, valid_edit_in, valid_edit_out]
+
+        if None in skip_on_none:
+            self.log.debug(" environment no set")
+            return
 
         assert int(valid_fps) == int(scene_fps), (
             "The FPS is set to %sfps and not to %sfps"

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -3,7 +3,8 @@ import pyblish.api
 
 
 class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
-    """
+    """ Checks your scene with editorial info
+
     All the info that gets validated
     has been set by the projects
     bat files.
@@ -16,35 +17,38 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
     label = "Validate Project Edit Info"
     optional = True
     order = pyblish.api.ValidatorOrder
-    hosts = ["maya"]
 
     def process(self, context):
         from maya import cmds
 
-        sceneIn = cmds.playbackOptions(query=True, animationStartTime=True)
-        sceneOut = cmds.playbackOptions(query=True, animationEndTime=True)
-        sceneFPS = {
-            "12fps" : 12,
-            "game"  : 15,
-            "film"  : 24,
-            "pal"   : 25,
-            "ntsc"  : 30,
-            "show"  : 48,
-            "palf"  : 50,
-            "ntscf" : 60}.get(cmds.currentUnit(query=True, time=True))
+        scene_in = cmds.playbackOptions(query=True, animationStartTime=True)
+        scene_out = cmds.playbackOptions(query=True, animationEndTime=True)
+        scene_fps = {
+                "12fps" : 12,
+                "16fps" : 16,
+                "game"  : 15,
+                "film"  : 24,
+                "pal"   : 25,
+                "ntsc"  : 30,
+                "show"  : 48,
+                "palf"  : 50,
+                "ntscf" : 60}.get(cmds.currentUnit(query=True, time=True))
 
-        validFPS = context.data.get("project_fps")
-        validEditIn = context.data.get("project_edit_in")
-        validEditOut = context.data.get("project_edit_out")
+        if scene_fps is None:
+            scene_fps = "New Value"
 
-        assert validFPS == sceneFPS, (
-            ("The FPS is set to %s" % sceneFPS) +
-            ("fps and not to %sfps" % validFPS))
+        valid_fps = context.data.get("project_fps")
+        valid_edit_in = context.data.get("project_edit_in")
+        valid_edit_out = context.data.get("project_edit_out")
 
-        assert sceneIn == validEditIn, (
-            ("Animation Start is set to %s" % sceneIn) +
-            (" and not set to \"%s\"" % validEditIn))
+        assert valid_fps == scene_fps, (
+            "The FPS is set to %sfps and not to %sfps"
+            % (scene_fps, valid_fps))
 
-        assert sceneOut == validEditOut, (
-            ("Animation End is set to %s" % sceneOut) +
-            (" and not set to \"%s\"" % validEditOut))
+        assert scene_in == valid_edit_in, (
+            "Animation Start is set to %s and not set to \"%s\""
+            % (scene_in, valid_edit_in))
+
+        assert scene_out == valid_edit_out, (
+            "Animation End is set to %s and not set to \"%s\""
+            % (scene_out, valid_edit_out))

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -3,14 +3,11 @@ import pyblish.api
 
 
 class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
-    """ Checks your scene with editorial info
+    """Checks your scene with editorial info
 
-    All the info that gets validated
-    has been set by the projects
-    bat files.
-    If you are surtain that the info
-    is incorrect, talk to
-    project Supervisor with haste !
+    All the info that gets validated has been set by the projects bat files.
+    If you are certain that the info is incorrect, talk to your project
+    Supervisor with haste!
 
     """
 
@@ -35,23 +32,25 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
                 "ntscf" : 60}.get(cmds.currentUnit(query=True, time=True))
 
         if scene_fps is None:
-            scene_fps = "New Value"
+            scene_fps = "a Strange "
 
-        valid_fps = context.data.get("projectFPS")
-        valid_edit_in = context.data.get("projectEditIn")
-        valid_edit_out = context.data.get("projectEditOut")
+        if "environment" not in context.data:
+            continue
 
-        if valid_fps is None:
-            return None
+        env = context.data.get("environment")
 
-        assert valid_fps == scene_fps, (
+        valid_fps = env.get("mindbenderFps")
+        valid_edit_in = env.get("mindbenderEditIn")
+        valid_edit_out = env.get("mindbenderEditOut")
+
+        assert int(valid_fps) == int(scene_fps), (
             "The FPS is set to %sfps and not to %sfps"
             % (scene_fps, valid_fps))
 
-        assert scene_in == valid_edit_in, (
+        assert int(scene_in) == int(valid_edit_in), (
             "Animation Start is set to %s and not set to \"%s\""
             % (scene_in, valid_edit_in))
 
-        assert scene_out == valid_edit_out, (
+        assert int(scene_out) == int(valid_edit_out), (
             "Animation End is set to %s and not set to \"%s\""
             % (scene_out, valid_edit_out))

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -22,7 +22,7 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         from maya import cmds
 
         sceneIn = cmds.playbackOptions(query=True, animationStartTime=True)
-        sceneOUT = cmds.playbackOptions(query=True, animationEndTime=True)
+        sceneOut = cmds.playbackOptions(query=True, animationEndTime=True)
         sceneFPS = {
             "12fps" : 12,
             "game"  : 15,
@@ -42,7 +42,9 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
             ("fps and not to %sfps" % validFPS))
 
         assert sceneIn == validEditIn, (
-            "Animation Start is not set to \"%s\"" % validEditIn)
+            ("Animation Start is set to %s" % sceneIn) +
+            (" and not set to \"%s\"" % validEditIn))
 
-        assert sceneOUT == validEditOut, (
-            "Animation End is not set to \"%s\"" % validEditOut)
+        assert sceneOut == validEditOut, (
+            ("Animation End is set to %s" % sceneOut) +
+            ("not set to \"%s\"" % validEditOut))

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -35,13 +35,14 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
             scene_fps = "a strange "
 
         if "environment" not in context.data:
-            continue
+            self.log.debug(" environment no set")
+            return
 
-        env = context.data.get("environment")
+        env = context.data.get("environment", dict())
 
-        valid_fps = env.get("mindbenderFps")
-        valid_edit_in = env.get("mindbenderEditIn")
-        valid_edit_out = env.get("mindbenderEditOut")
+        valid_fps = env.get("mindbenderFps", 0)
+        valid_edit_in = env.get("mindbenderEditIn", 0)
+        valid_edit_out = env.get("mindbenderEditOut", 0)
 
         assert int(valid_fps) == int(scene_fps), (
             "The FPS is set to %sfps and not to %sfps"

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -38,10 +38,11 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         validEditOut = context.data.get("project_edit_out")
 
         assert validFPS == sceneFPS, (
-            ("The FPS is set to %s" % sceneFPS) + ("fps and not to %sfps" % validFPS))
+            ("The FPS is set to %s" % sceneFPS) +
+            ("fps and not to %sfps" % validFPS))
 
         assert sceneIn == validEditIn, (
-            "The Start is not set to \"%s\"" % validEditIn)
+            "Animation Start is not set to \"%s\"" % validEditIn)
 
         assert sceneOUT == validEditOut, (
-            "The End is not set to \"%s\"" % validEditOut)
+            "Animation End is not set to \"%s\"" % validEditOut)

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -8,7 +8,6 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
     All the info that gets validated has been set by the projects bat files.
     If you are certain that the info is incorrect, talk to your project
     Supervisor with haste!
-
     """
 
     label = "Validate Project Edit Info"
@@ -43,7 +42,7 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         skip_on_none = [valid_fps, valid_edit_in, valid_edit_out]
 
         if None in skip_on_none:
-            self.log.debug(" environment no set")
+            self.log.debug(" environment not set")
             return
 
         assert int(valid_fps) == int(scene_fps), (

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -47,4 +47,4 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
 
         assert sceneOut == validEditOut, (
             ("Animation End is set to %s" % sceneOut) +
-            ("not set to \"%s\"" % validEditOut))
+            (" and not set to \"%s\"" % validEditOut))

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -32,7 +32,7 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
                 "ntscf" : 60}.get(cmds.currentUnit(query=True, time=True))
 
         if scene_fps is None:
-            scene_fps = "a Strange "
+            scene_fps = "a strange "
 
         if "environment" not in context.data:
             continue

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -38,7 +38,7 @@ class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
         validEditOut = context.data.get("project_edit_out")
 
         assert validFPS == sceneFPS, (
-            "The FPS is not set to \"%s\"" % validFPS)
+            ("The FPS is set to %s" % sceneFPS) + ("fps and not to %sfps" % validFPS))
 
         assert sceneIn == validEditIn, (
             "The Start is not set to \"%s\"" % validEditIn)

--- a/mindbender/maya/plugins/validate_project_editorial_info.py
+++ b/mindbender/maya/plugins/validate_project_editorial_info.py
@@ -1,0 +1,47 @@
+# validate_project_editorial_info.py
+import pyblish.api
+
+
+class ValidateMindbenderProjectEditInfo(pyblish.api.ContextPlugin):
+    """
+    All the info that gets validated
+    has been set by the projects
+    bat files.
+    If you are surtain that the info
+    is incorrect, talk to
+    project Supervisor with haste !
+
+    """
+
+    label = "Validate Project Edit Info"
+    optional = True
+    order = pyblish.api.ValidatorOrder
+    hosts = ["maya"]
+
+    def process(self, context):
+        from maya import cmds
+
+        sceneIn = cmds.playbackOptions(query=True, animationStartTime=True)
+        sceneOUT = cmds.playbackOptions(query=True, animationEndTime=True)
+        sceneFPS = {
+            "12fps" : 12,
+            "game"  : 15,
+            "film"  : 24,
+            "pal"   : 25,
+            "ntsc"  : 30,
+            "show"  : 48,
+            "palf"  : 50,
+            "ntscf" : 60}.get(cmds.currentUnit(query=True, time=True))
+
+        validFPS = context.data.get("project_fps")
+        validEditIn = context.data.get("project_edit_in")
+        validEditOut = context.data.get("project_edit_out")
+
+        assert validFPS == sceneFPS, (
+            "The FPS is not set to \"%s\"" % validFPS)
+
+        assert sceneIn == validEditIn, (
+            "The Start is not set to \"%s\"" % validEditIn)
+
+        assert sceneOUT == validEditOut, (
+            "The End is not set to \"%s\"" % validEditOut)

--- a/mindbender/maya/pythonpath/userSetup.py
+++ b/mindbender/maya/pythonpath/userSetup.py
@@ -38,6 +38,8 @@ def setup():
     cmds.setAttr("defaultResolution.width", RESOLUTION_WIDTH)
     cmds.setAttr("defaultResolution.height", RESOLUTION_HEIGHT)
     cmds.currentUnit(time=FPS)
+    cmds.playbackOptions(minTime=EDIT_IN)
+    cmds.playbackOptions(maxTime=EDIT_OUT)
     cmds.playbackOptions(animationStartTime=EDIT_IN)
     cmds.playbackOptions(animationEndTime=EDIT_OUT)
 

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -48,7 +48,7 @@ def setup():
     # Setup environment
     os.environ["MINDBENDER_ASSETPATH"] = assetdir
     os.environ["MINDBENDER_SILO"] = "assets"
-    os.environ["MINDBENDER_FPS"] = "25"
+    os.environ["MINDBENDER_FPS"] = "24"
     os.environ["MINDBENDER_EDIT_IN"] = ""
     os.environ["MINDBENDER_EDIT_OUT"] = ""
 

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -48,6 +48,9 @@ def setup():
     # Setup environment
     os.environ["MINDBENDER_ASSETPATH"] = assetdir
     os.environ["MINDBENDER_SILO"] = "assets"
+    os.environ["MINDBENDER_FPS"] = "30"
+    os.environ["MINDBENDER_EDIT_IN"] = ""
+    os.environ["MINDBENDER_EDIT_OUT"] = ""
 
 
 def teardown():

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -48,9 +48,6 @@ def setup():
     # Setup environment
     os.environ["MINDBENDER_ASSETPATH"] = assetdir
     os.environ["MINDBENDER_SILO"] = "assets"
-    os.environ["MINDBENDER_FPS"] = "24"
-    os.environ["MINDBENDER_EDIT_IN"] = "1"
-    os.environ["MINDBENDER_EDIT_OUT"] = "48"
 
 
 def teardown():

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -50,7 +50,7 @@ def setup():
     os.environ["MINDBENDER_SILO"] = "assets"
     os.environ["MINDBENDER_FPS"] = "24"
     os.environ["MINDBENDER_EDIT_IN"] = "1"
-    os.environ["MINDBENDER_EDIT_OUT"] = "200"
+    os.environ["MINDBENDER_EDIT_OUT"] = "48"
 
 
 def teardown():

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -48,7 +48,7 @@ def setup():
     # Setup environment
     os.environ["MINDBENDER_ASSETPATH"] = assetdir
     os.environ["MINDBENDER_SILO"] = "assets"
-    os.environ["MINDBENDER_FPS"] = "30"
+    os.environ["MINDBENDER_FPS"] = "25"
     os.environ["MINDBENDER_EDIT_IN"] = ""
     os.environ["MINDBENDER_EDIT_OUT"] = ""
 

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -49,8 +49,8 @@ def setup():
     os.environ["MINDBENDER_ASSETPATH"] = assetdir
     os.environ["MINDBENDER_SILO"] = "assets"
     os.environ["MINDBENDER_FPS"] = "24"
-    os.environ["MINDBENDER_EDIT_IN"] = ""
-    os.environ["MINDBENDER_EDIT_OUT"] = ""
+    os.environ["MINDBENDER_EDIT_IN"] = "1"
+    os.environ["MINDBENDER_EDIT_OUT"] = "200"
 
 
 def teardown():

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -28,6 +28,6 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
             key = "".join(k.title() for k in key.split("_"))
 
             # Decorate key to match mixedCase
-            deckey = key[0].lower() + key[1:]
+            key = key[0].lower() + key[1:]
 
-            context.data["environment"][deckey] = value
+            context.data["environment"][key] = value

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -20,17 +20,17 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
         mindbender_edit_in = os.getenv("MINDBENDER_EDIT_IN")
         mindbender_edit_out = os.getenv("MINDBENDER_EDIT_OUT")
 
-        if mindbender_fps is not None:
-            context.data["project_fps"] = int(mindbender_fps)
-        elif mindbender_fps == "" or mindbender_fps is None:
+        if mindbender_fps == "" or mindbender_fps is None:
             context.data["project_fps"] = 25
+        elif mindbender_fps is not None:
+            context.data["project_fps"] = int(mindbender_fps)
 
-        if mindbender_edit_in is not None:
-            context.data["project_edit_in"] = int(mindbender_edit_in)
-        elif mindbender_edit_in == "" or mindbender_edit_in is None:
+        if mindbender_edit_in == "" or mindbender_edit_in is None:
             context.data["project_edit_in"] = 101
+        elif mindbender_edit_in is not None:
+            context.data["project_edit_in"] = int(mindbender_edit_in)
 
-        if mindbender_edit_out is not None:
-            context.data["project_edit_out"] = int(mindbender_edit_out)
-        elif mindbender_edit_out == "" or mindbender_edit_out is None:
+        if mindbender_edit_out == "" or mindbender_edit_out is None:
             context.data["project_edit_out"] = 201
+        elif mindbender_edit_out is not None:
+            context.data["project_edit_out"] = int(mindbender_edit_out)

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -28,6 +28,6 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
             key = "".join(k.title() for k in key.split("_"))
 
             # Decorate key to match mixedCase
-            key = key[0].lower + key[1:]
+            deckey = key[0].lower() + key[1:]
 
-            context.data["environment"][key] = value
+            context.data["environment"][deckey] = value

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -23,14 +23,11 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
             if not key.startswith(prefix):
                 continue
 
-            key = key[len(prefix):]
-
-            # Convert EDIT_IN to EditIn, FPS to Fps.
+            # Convert MINDBENDER_EDIT_IN to MindbenderEditIn
+            # or MINDBENDER_FPS to MindbenderFps
             key = "".join(k.title() for k in key.split("_"))
 
-            # Decorate key with "mindbender" to match prev namning convention
-            decoration = prefix.replace("_", "")
-            decoration = decoration.lower()
-            key = decoration + key
+            # Decorate key to match mixedCase
+            key = key[0].lower + key[1:]
 
             context.data["environment"][key] = value

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -15,26 +15,22 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
     def process(self, context):
         import os
 
-        for env in os.environ:
-            if "MINDBENDER" in env:
-                if "FPS" in env:
-                    mindbender_fps = env
-                if "EDIT_IN" in env:
-                    mindbender_edit_in = env
-                if "EDIT_OUT" in env:
-                    mindbender_edit_out = env
+        if "environment" not in context.data:
+            context.data["environment"] = dict()
 
-        if mindbender_fps == "" or mindbender_fps is None:
-            context.data["projectFPS"] = 25
-        elif mindbender_fps is not None:
-            context.data["projectFPS"] = int(mindbender_fps)
+        prefix = "MINDBENDER_"
+        for key, value in os.environ.items():
+            if not key.startswith(prefix):
+                continue
 
-        if mindbender_edit_in == "" or mindbender_edit_in is None:
-            context.data["projectEditIn"] = 101
-        elif mindbender_edit_in is not None:
-            context.data["projectEditIn"] = int(mindbender_edit_in)
+            key = key[len(prefix):]
 
-        if mindbender_edit_out == "" or mindbender_edit_out is None:
-            context.data["projectEditOut"] = 201
-        elif mindbender_edit_out is not None:
-            context.data["projectEditOut"] = int(mindbender_edit_out)
+            # Convert EDIT_IN to EditIn, FPS to Fps.
+            key = "".join(k.title() for k in key.split("_"))
+
+            # Decorate key with "mindbender" to match prev namning convention
+            decoration = prefix.replace("_", "")
+            decoration = decoration.lower()
+            key = decoration + key
+
+            context.data["environment"][key] = value

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -22,15 +22,15 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
 
         if mindbender_fps is not None:
             context.data["project_fps"] = int(mindbender_fps)
-        elif mindbender_fps == "":
+        elif mindbender_fps == "" or mindbender_fps is None:
             context.data["project_fps"] = 25
 
         if mindbender_edit_in is not None:
             context.data["project_edit_in"] = int(mindbender_edit_in)
-        elif mindbender_edit_in == "":
+        elif mindbender_edit_in == "" or mindbender_edit_in is None:
             context.data["project_edit_in"] = 101
 
         if mindbender_edit_out is not None:
             context.data["project_edit_out"] = int(mindbender_edit_out)
-        elif mindbender_edit_out == "":
+        elif mindbender_edit_out == "" or mindbender_edit_out is None:
             context.data["project_edit_out"] = 201

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -25,16 +25,16 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
                     mindbender_edit_out = env
 
         if mindbender_fps == "" or mindbender_fps is None:
-            context.data["projectFPS"] = 24
+            context.data["projectFPS"] = 25
         elif mindbender_fps is not None:
             context.data["projectFPS"] = int(mindbender_fps)
 
         if mindbender_edit_in == "" or mindbender_edit_in is None:
-            context.data["projectEditIn"] = 1
+            context.data["projectEditIn"] = 101
         elif mindbender_edit_in is not None:
             context.data["projectEditIn"] = int(mindbender_edit_in)
 
         if mindbender_edit_out == "" or mindbender_edit_out is None:
-            context.data["projectEditOut"] = 48
+            context.data["projectEditOut"] = 201
         elif mindbender_edit_out is not None:
             context.data["projectEditOut"] = int(mindbender_edit_out)

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -1,0 +1,36 @@
+# collect_project_editorial_info.py
+import pyblish.api
+
+
+class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
+    """Store projects editorial info at the time of publish"""
+
+    label = "Collect Project Edit Info"
+    order = pyblish.api.CollectorOrder
+    hosts = ["maya"]
+    families = [
+        # More will come
+        "mindbender.animation"
+    ]
+
+    def process(self, context):
+        import os
+
+        mindbender_fps = os.getenv("MINDBENDER_FPS")
+        mindbender_edit_in = os.getenv("MINDBENDER_EDIT_IN")
+        mindbender_edit_out = os.getenv("MINDBENDER_EDIT_OUT")
+
+        if mindbender_fps is not None:
+            context.data["project_fps"] = int(mindbender_fps)
+        elif mindbender_fps == "":
+            context.data["project_fps"] = 25
+
+        if mindbender_edit_in is not None:
+            context.data["project_edit_in"] = int(mindbender_edit_in)
+        elif mindbender_edit_in == "":
+            context.data["project_edit_in"] = 101
+
+        if mindbender_edit_out is not None:
+            context.data["project_edit_out"] = int(mindbender_edit_out)
+        elif mindbender_edit_out == "":
+            context.data["project_edit_out"] = 201

--- a/mindbender/plugins/collect_project_editorial_info.py
+++ b/mindbender/plugins/collect_project_editorial_info.py
@@ -9,28 +9,32 @@ class CollectMindbenderEditInfo(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder
     hosts = ["maya"]
     families = [
-        # More will come
         "mindbender.animation"
     ]
 
     def process(self, context):
         import os
 
-        mindbender_fps = os.getenv("MINDBENDER_FPS")
-        mindbender_edit_in = os.getenv("MINDBENDER_EDIT_IN")
-        mindbender_edit_out = os.getenv("MINDBENDER_EDIT_OUT")
+        for env in os.environ:
+            if "MINDBENDER" in env:
+                if "FPS" in env:
+                    mindbender_fps = env
+                if "EDIT_IN" in env:
+                    mindbender_edit_in = env
+                if "EDIT_OUT" in env:
+                    mindbender_edit_out = env
 
         if mindbender_fps == "" or mindbender_fps is None:
-            context.data["project_fps"] = 25
+            context.data["projectFPS"] = 24
         elif mindbender_fps is not None:
-            context.data["project_fps"] = int(mindbender_fps)
+            context.data["projectFPS"] = int(mindbender_fps)
 
         if mindbender_edit_in == "" or mindbender_edit_in is None:
-            context.data["project_edit_in"] = 101
+            context.data["projectEditIn"] = 1
         elif mindbender_edit_in is not None:
-            context.data["project_edit_in"] = int(mindbender_edit_in)
+            context.data["projectEditIn"] = int(mindbender_edit_in)
 
         if mindbender_edit_out == "" or mindbender_edit_out is None:
-            context.data["project_edit_out"] = 201
+            context.data["projectEditOut"] = 48
         elif mindbender_edit_out is not None:
-            context.data["project_edit_out"] = int(mindbender_edit_out)
+            context.data["projectEditOut"] = int(mindbender_edit_out)


### PR DESCRIPTION
**Currently:**
When launching maya for the first time on a new task, the scene gets info and settings from what is defined in the project bats.

**Addition:**
I have added a new feature, inspired by #35, two new plugins
- A context collector for pyblish, which reads the global variables set by the project bats and stores the info in _context.data_

- A validator for maya which gives the user the option to check if their scenes frame-rate and frame-range is the same as the contexts stored info.

**This is a first pass at this plugin, please check my work to see if you can find improvements.**

**Future improvments:**
- make copy of [validate_project_editorial_info.py](https://github.com/mindbender-studio/core/compare/master...LegacyID1991:additionTo35?expand=1#diff-4a65e400db74a46e2cac1446980258e4) and change variable value to app specific commands between [24](https://github.com/mindbender-studio/core/compare/master...LegacyID1991:additionTo35?expand=1#diff-4a65e400db74a46e2cac1446980258e4R24) and [35](https://github.com/mindbender-studio/core/compare/master...LegacyID1991:additionTo35?expand=1#diff-4a65e400db74a46e2cac1446980258e4R35)

- make the [collect_project_editorial_info.py](https://github.com/mindbender-studio/core/compare/master...LegacyID1991:additionTo35?expand=1#diff-dd1f32159ee605b570b8cc4798b5a92e) look at the bat files instead of looking at the global variables, as the global variables are only set on start up, then artist would need to reboot their app to get their editorial info updated. 