### PR TITLE
fix for issue 68

### DIFF
--- a/bin/houdini.bat
+++ b/bin/houdini.bat
@@ -23,7 +23,7 @@ if "%MINDBENDER_ASSET%"=="0" goto :missing_set_asset
 :: If user forgets to include task with "houdini"..
 if "%1"=="" goto :missing_task
 
-set MINDBENDER_WORKDIR=%cd%\work\%1\%USERNAME%\houdini
+set MINDBENDER_WORKDIR=%cd%\work\%1\houdini
 if Not exist %MINDBENDER_WORKDIR% (
     echo Creating new task "%1"..
 

--- a/bin/maya.bat
+++ b/bin/maya.bat
@@ -25,7 +25,7 @@ if "%1"=="" goto :missing_task
 
 if not exist "%1" goto :missing_taskfolder
 
-set MINDBENDER_WORKDIR=%CD%\%1\%USERNAME%\maya
+set MINDBENDER_WORKDIR=%CD%\%1\maya
 if Not exist %MINDBENDER_WORKDIR% (
 	echo Creating new task "%1"..
 

--- a/bin/nuke.bat
+++ b/bin/nuke.bat
@@ -25,7 +25,7 @@ if "%1"=="" goto :missing_task
 
 if not exist "%1" goto :missing_taskfolder
 
-set MINDBENDER_WORKDIR=%cd%\%1\%USERNAME%\nuke
+set MINDBENDER_WORKDIR=%cd%\%1\nuke
 if Not exist %MINDBENDER_WORKDIR% (
     echo Creating new task "%1"..
 


### PR DESCRIPTION
Related to #68 

removed userName folder from work folder structure in accord with issue 68

- This will not however move all of the present work files from old location, they still need to be manually copyd or moved to the new folder when the new tasks are created.

From now on all artists will work in the same app work dir under the tasks for each asset or shot.

