### PR TITLE
Implement callable data values

### DIFF
--- a/mindbender/maya/lib.py
+++ b/mindbender/maya/lib.py
@@ -228,9 +228,28 @@ def imprint(node, data):
         node (str): Long name of node
         data (dict): Dictionary of key/value pairs
 
+    Example:
+        >>> from maya import cmds
+        >>> def compute():
+        ...   return 6
+        ...
+        >>> cube, generator = cmds.polyCube()
+        >>> imprint(cube, {
+        ...   "regularString": "myFamily",
+        ...   "computedValue": lambda: compute()
+        ... })
+        ...
+        >>> cmds.getAttr(cube + ".computedValue")
+        6
+
     """
 
     for key, value in data.items():
+
+        if callable(value):
+            # Support values evaluated at imprint
+            value = value()
+
         if isinstance(value, bool):
             add_type = {"attributeType": "bool"}
             set_type = {"keyable": False, "channelBox": True}

--- a/mindbender/maya/pipeline.py
+++ b/mindbender/maya/pipeline.py
@@ -178,10 +178,10 @@ def _register_families():
         label="Animation",
         help="Any character or prop animation",
         data={
-            "startFrame": cmds.playbackOptions(query=True,
-                                               animationStartTime=True),
-            "endFrame": cmds.playbackOptions(query=True,
-                                             animationEndTime=True),
+            "startFrame": lambda: cmds.playbackOptions(
+                query=True, animationStartTime=True),
+            "endFrame": lambda: cmds.playbackOptions(
+                query=True, animationEndTime=True),
         }
     )
 
@@ -347,14 +347,16 @@ def create(name, family, options=None):
 
     # Resolve template
     for key, value in data.items():
-        try:
-            data[key] = str(value).format(
-                name=name,
-                family=family_["name"]
-            )
-        except KeyError as e:
-            raise KeyError("Invalid dynamic property: %s" % e)
+        if isinstance(value, basestring):
+            try:
+                data[key] = str(value).format(
+                    name=name,
+                    family=family_["name"]
+                )
+            except KeyError as e:
+                raise KeyError("Invalid dynamic property: %s" % e)
 
+    print("About to imprint")
     lib.imprint(instance, data)
 
     return instance


### PR DESCRIPTION
Alternative to https://github.com/mindbender-studio/core/pull/95.

Values captured by animation instances at run-time now contain the animation range found at the time of creation. Those values are determined by the globally set environment variables involved with range.

@LegacyID1991 let me know what you think.