### PR TITLE
Preparations for the Launcher

### DIFF
--- a/bin/_mkproject.bat
+++ b/bin/_mkproject.bat
@@ -44,7 +44,6 @@ if not exist %MINDBENDER_PROJECTPATH% (
 )
 
 :: Establish base directories for ls() and search() functions.
-set MINDBENDER_ROOT=%MINDBENDER_PROJECTPATH%
 set MINDBENDER_SILO=%4
 
 pushd %MINDBENDER_PROJECTPATH%\%MINDBENDER_SILO%

--- a/bin/new.bat
+++ b/bin/new.bat
@@ -42,7 +42,7 @@ echo new project %2 created
 goto :eof
 
 :copy_asset
-if not "%CD%"=="%MINDBENDER_ROOT%\%MINDBENDER_SILO%" goto :missing
+if not "%CD%"=="%MINDBENDER_PROJECTPATH%\%MINDBENDER_SILO%" goto :missing
 >NUL copy %MINDBENDER_CORE%\template\AssetName.bat .
 >NUL ren AssetName.bat %2.bat
 if "%1"=="shot" echo new shot %2 created

--- a/mindbender/pipeline.py
+++ b/mindbender/pipeline.py
@@ -484,7 +484,7 @@ def registered_root():
     """Return currently registered root"""
     return (
         _registered_root["_"] or
-        os.getenv("MINDBENDER_ROOT") or ""
+        os.getenv("MINDBENDER_PROJECTPATH") or ""
     ).replace("\\", "/")
 
 

--- a/mindbender/pipeline.py
+++ b/mindbender/pipeline.py
@@ -208,6 +208,8 @@ def ls(silos=None):
 
     """
 
+    assert registered_root(), "No root registered"
+
     silos = silos or registered_silos()
 
     assert isinstance(silos, list), (

--- a/mindbender/tools/loader/app.py
+++ b/mindbender/tools/loader/app.py
@@ -185,6 +185,17 @@ class Window(QtWidgets.QDialog):
 
         state = self.data["state"]
 
+        if not api.registered_root():
+            item = QtWidgets.QListWidgetItem("No root registered.")
+            item.setData(QtCore.Qt.ItemIsEnabled, False)
+            state["running"] = False
+
+            assets_model.setFocus()
+            # self.data["button"]["load"].show()
+            self.data["button"]["stop"].hide()
+
+            return assets_model.addItem(item)
+
         has = {"assets": False}
 
         module = sys.modules[__name__]
@@ -228,7 +239,6 @@ class Window(QtWidgets.QDialog):
                 item.setData(QtCore.Qt.ItemIsEnabled, False)
                 assets_model.addItem(item)
 
-            # assets_model.setCurrentItem(assets_model.item(0))
             assets_model.setFocus()
             self.data["button"]["load"].show()
             self.data["button"]["stop"].hide()


### PR DESCRIPTION
A few minor tweaks to simplify life for the Launcher.

`MINDBENDER_ROOT` was always set to `MINDBENDER_PROJECTPATH` so I went ahead and made it official. It may be overridden via `api.register_root("/path/here")`.
