### PR TITLE
Revert back to MINDBENDER_ROOT

### DIFF
--- a/bin/_mkproject.bat
+++ b/bin/_mkproject.bat
@@ -44,6 +44,7 @@ if not exist %MINDBENDER_PROJECTPATH% (
 )
 
 :: Establish base directories for ls() and search() functions.
+set MINDBENDER_ROOT=%MINDBENDER_PROJECTPATH%
 set MINDBENDER_SILO=%4
 
 pushd %MINDBENDER_PROJECTPATH%\%MINDBENDER_SILO%

--- a/bin/new.bat
+++ b/bin/new.bat
@@ -42,7 +42,7 @@ echo new project %2 created
 goto :eof
 
 :copy_asset
-if not "%CD%"=="%MINDBENDER_PROJECTPATH%\%MINDBENDER_SILO%" goto :missing
+if not "%CD%"=="%MINDBENDER_ROOT%\%MINDBENDER_SILO%" goto :missing
 >NUL copy %MINDBENDER_CORE%\template\AssetName.bat .
 >NUL ren AssetName.bat %2.bat
 if "%1"=="shot" echo new shot %2 created

--- a/mindbender/pipeline.py
+++ b/mindbender/pipeline.py
@@ -484,7 +484,7 @@ def registered_root():
     """Return currently registered root"""
     return (
         _registered_root["_"] or
-        os.getenv("MINDBENDER_PROJECTPATH") or ""
+        os.getenv("MINDBENDER_ROOT") or ""
     ).replace("\\", "/")
 
 


### PR DESCRIPTION
We need this in order to support child directories within a project where assets are kept.