### PR TITLE
Enable selecting Pyblish GUI via environment PYBLISHGUI environment variable

### DIFF
--- a/mindbender/maya/pythonpath/userSetup.py
+++ b/mindbender/maya/pythonpath/userSetup.py
@@ -10,9 +10,6 @@ def setup():
         "mindbender-core depends on pyblish_maya which has not "
         "yet been setup. Run pyblish_maya.setup()")
 
-    from pyblish import api
-    api.register_gui("pyblish_lite")
-
     from mindbender import api, maya
     api.install(maya)
 


### PR DESCRIPTION
Selecting the GUI is now made via the Launcher or .bat files.

```bash
$ set PYBLISHGUI=pyblish_lite
```

This will enable us to dynamically select a GUI from the Launcher (later on).