### PR TITLE
Creator plugins

### DIFF
--- a/mindbender/__init__.py
+++ b/mindbender/__init__.py
@@ -10,8 +10,8 @@ the currently held state of mindbender-core.
 _registered_data = dict()
 _registered_families = dict()
 _registered_formats = list()
-_registered_loaders = list()
+_registered_plugins = dict()
+_registered_plugin_paths = dict()
 _registered_silos = set()
-_registered_loader_paths = set()
 _registered_root = {"_": ""}
 _registered_host = {"_": None}

--- a/mindbender/api.py
+++ b/mindbender/api.py
@@ -29,26 +29,20 @@ from .pipeline import (
     discover,
 
     register_root,
-    register_data,
     register_host,
     register_format,
     register_silo,
-    register_family,
     register_plugin_path,
     register_plugin,
 
     registered_host,
-    registered_families,
     registered_plugin_paths,
     registered_formats,
-    registered_data,
     registered_root,
     registered_silos,
 
     deregister_plugins,
     deregister_format,
-    deregister_family,
-    deregister_data,
 )
 
 from .lib import (
@@ -77,10 +71,8 @@ __all__ = [
     "discover",
 
     "register_host",
-    "register_data",
     "register_format",
     "register_silo",
-    "register_family",
     "register_plugin_path",
     "register_plugin",
     "register_root",
@@ -89,14 +81,10 @@ __all__ = [
     "registered_silos",
     "registered_plugin_paths",
     "registered_host",
-    "registered_families",
     "registered_formats",
-    "registered_data",
 
     "deregister_plugins",
     "deregister_format",
-    "deregister_family",
-    "deregister_data",
 
     "format_staging_dir",
     "format_shared_dir",

--- a/mindbender/api.py
+++ b/mindbender/api.py
@@ -25,7 +25,8 @@ from .pipeline import (
     uninstall,
 
     Loader,
-    discover_loaders,
+    Creator,
+    discover,
 
     register_root,
     register_data,
@@ -33,12 +34,12 @@ from .pipeline import (
     register_format,
     register_silo,
     register_family,
-    register_loader_path,
-    register_plugins,
+    register_plugin_path,
+    register_plugin,
 
     registered_host,
     registered_families,
-    registered_loader_paths,
+    registered_plugin_paths,
     registered_formats,
     registered_data,
     registered_root,
@@ -48,7 +49,6 @@ from .pipeline import (
     deregister_format,
     deregister_family,
     deregister_data,
-    deregister_loader_path,
 )
 
 from .lib import (
@@ -73,20 +73,21 @@ __all__ = [
     "schema",
 
     "Loader",
-    "discover_loaders",
+    "Creator",
+    "discover",
 
     "register_host",
     "register_data",
     "register_format",
     "register_silo",
     "register_family",
-    "register_loader_path",
-    "register_plugins",
+    "register_plugin_path",
+    "register_plugin",
     "register_root",
 
     "registered_root",
     "registered_silos",
-    "registered_loader_paths",
+    "registered_plugin_paths",
     "registered_host",
     "registered_families",
     "registered_formats",
@@ -96,7 +97,6 @@ __all__ = [
     "deregister_format",
     "deregister_family",
     "deregister_data",
-    "deregister_loader_path",
 
     "format_staging_dir",
     "format_shared_dir",

--- a/mindbender/maya/__init__.py
+++ b/mindbender/maya/__init__.py
@@ -8,6 +8,8 @@ from .pipeline import (
     install,
     uninstall,
 
+    Creator,
+
     ls,
     load,
     create,
@@ -34,6 +36,8 @@ from .lib import (
 __all__ = [
     "install",
     "uninstall",
+
+    "Creator",
 
     "ls",
     "load",

--- a/mindbender/maya/creators/mindbender_animation.py
+++ b/mindbender/maya/creators/mindbender_animation.py
@@ -1,0 +1,20 @@
+from mindbender import maya
+
+
+class CreateAnimation(maya.Creator):
+    """Any character or prop animation"""
+
+    name = "animationDefault"
+    family = "mindbender.animation"
+    label = "Animation"
+
+    def __init__(self, *args, **kwargs):
+        super(CreateAnimation, self).__init__(*args, **kwargs)
+        from maya import cmds
+
+        self.data.update({
+            "startFrame": lambda: cmds.playbackOptions(
+                query=True, animationStartTime=True),
+            "endFrame": lambda: cmds.playbackOptions(
+                query=True, animationEndTime=True),
+        })

--- a/mindbender/maya/creators/mindbender_lookdev.py
+++ b/mindbender/maya/creators/mindbender_lookdev.py
@@ -1,0 +1,9 @@
+from mindbender import maya
+
+
+class CreateLookdev(maya.Creator):
+    """Shaders, textures and look"""
+
+    name = "lookdevDefault"
+    label = "Lookdev"
+    family = "mindbender.lookdev"

--- a/mindbender/maya/creators/mindbender_model.py
+++ b/mindbender/maya/creators/mindbender_model.py
@@ -1,0 +1,9 @@
+from mindbender import maya
+
+
+class CreateModel(maya.Creator):
+    """Polygonal geometry for animation"""
+
+    name = "modelDefault"
+    label = "Model"
+    family = "mindbender.model"

--- a/mindbender/maya/creators/mindbender_rig.py
+++ b/mindbender/maya/creators/mindbender_rig.py
@@ -1,0 +1,9 @@
+from mindbender import maya
+
+
+class CreateRig(maya.Creator):
+    """Character rig"""
+
+    name = "rigDefault"
+    label = "Rig"
+    family = "mindbender.rig"

--- a/mindbender/maya/loaders/mindbender_animation.py
+++ b/mindbender/maya/loaders/mindbender_animation.py
@@ -97,7 +97,7 @@ class CurvesLoader(api.Loader):
     def post_process(self, name, namespace, context):
         import os
         from maya import cmds
-        from mindbender import api, maya, io
+        from mindbender import maya, io
 
         # Task-dependent post-process
         if os.getenv("MINDBENDER_TASK") != "animate":

--- a/mindbender/maya/loaders/mindbender_rig.py
+++ b/mindbender/maya/loaders/mindbender_rig.py
@@ -49,6 +49,7 @@ class RigLoader(api.Loader):
             # TODO(marcus): Hardcoding the family here, better separate this.
             maya.create(
                 name=maya.unique_name(asset, suffix="_SET"),
+                asset=context["asset"]["name"],
                 family="mindbender.animation",
                 options={"useSelection": True},
                 data={

--- a/mindbender/maya/pipeline.py
+++ b/mindbender/maya/pipeline.py
@@ -409,19 +409,6 @@ def create(name, asset, family, options=None, data=None):
 
     """
 
-    # Default data
-    _data = {
-        "id": "pyblish.mindbender.instance",
-        "family": family,
-        "asset": asset,
-        "subset": name
-    }
-
-    if data is not None:
-        data.update(_data)
-    else:
-        data = _data
-
     for Plugin in api.discover(api.Creator):
         has_family = family == Plugin.family
 

--- a/mindbender/maya/tests/test_workflow.py
+++ b/mindbender/maya/tests/test_workflow.py
@@ -151,10 +151,12 @@ def test_modeling():
     group = cmds.group(transform, name="ROOT")
 
     cmds.select(group, replace=True)
-    maya.create(name="modelDefault",
-                asset=os.environ["MINDBENDER_ASSET"],
-                family="mindbender.model",
-                options={"useSelection": True})
+    maya.create(
+        name="modelDefault",
+        asset=ASSET_NAME,
+        family="mindbender.model",
+        options={"useSelection": True}
+    )
 
     # Comply with save validator
     cmds.file(save=True)
@@ -211,7 +213,7 @@ def test_alembic_export():
 
     maya.create(
         name="animationDefault",
-        asset=os.environ["MINDBENDER_ASSET"],
+        asset=ASSET_NAME,
         family="mindbender.animation",
         options={"useSelection": True}
     )
@@ -272,7 +274,7 @@ def test_update():
     cmds.select(group, replace=True)
     maya.create(
         name="modelDefault",
-        asset=os.environ["MINDBENDER_ASSET"],
+        asset=ASSET_NAME,
         family="mindbender.model",
         options={"useSelection": True}
     )
@@ -329,7 +331,7 @@ def test_modeling_to_rigging():
     cmds.select(group, replace=True)
     maya.create(
         name="modelDefault",
-        asset=os.environ["MINDBENDER_ASSET"],
+        asset=ASSET_NAME,
         family="mindbender.model",
         options={"useSelection": True})
 
@@ -368,9 +370,10 @@ def test_modeling_to_rigging():
     cmds.select([group, out_set, controls_set], noExpand=True)
     maya.create(
         name="rigDefault",
+        asset=os.environ["MINDBENDER_ASSET"],
         family="mindbender.rig",
         options={"useSelection": True},
-        data={"asset": os.environ["MINDBENDER_ASSET"]})
+    )
 
     cmds.file(rename="temp.ma")
     cmds.file(save=True)

--- a/mindbender/mock.py
+++ b/mindbender/mock.py
@@ -1,0 +1,22 @@
+from mindbender import api
+
+
+class CreateModel(api.Creator):
+    name = "MyModelDefault"
+    label = "Model"
+    family = "mindbender.model"
+
+
+class CreateRig(api.Creator):
+    family = "mindbender.rig"
+
+
+class CreateAnimation(api.Creator):
+    family = "mindbender.animation"
+
+
+creators = [
+    CreateModel,
+    CreateRig,
+    CreateAnimation
+]

--- a/mindbender/pipeline.py
+++ b/mindbender/pipeline.py
@@ -10,14 +10,12 @@ from . import (
     io,
     lib,
 
-    _registered_families,
-    _registered_data,
+    _registered_host,
+    _registered_root,
     _registered_silos,
     _registered_formats,
     _registered_plugins,
     _registered_plugin_paths,
-    _registered_host,
-    _registered_root,
 )
 
 from .vendor import six
@@ -130,7 +128,14 @@ class Creator(object):
     def __init__(self, name, asset, options=None, data=None):
         self.name = name or self.name
         self.options = options
-        self.data = data
+
+        # Default data
+        self.data = dict({
+            "id": "pyblish.mindbender.instance",
+            "family": self.family,
+            "asset": asset,
+            "subset": name
+        }, **(data or {}))
 
     def process(self):
         pass
@@ -307,7 +312,8 @@ def register_host(host):
             "name",
             "family",
             "asset",
-            "options"
+            "options",
+            "data"
         ],
         "ls": [
         ],
@@ -402,62 +408,8 @@ def registered_silos():
     )
 
 
-def register_data(key, value, help=None):
-    """Register new default attribute
-
-    Arguments:
-        key (str): Name of data
-        value (object): Arbitrary value of data
-        help (str, optional): Briefly describe
-
-    """
-
-    _registered_data[key] = value
-
-
-def deregister_data(key):
-    _registered_data.pop(key)
-
-
-def register_family(name,
-                    label=None,
-                    data=None,
-                    help=None,
-                    loader=None):
-    """Register family and attributes for family
-
-    Arguments:
-        name (str): Name of family, e.g. mindbender.model
-        label (str): Nice name for family, e.g. Model
-        data (dict, optional): Additional data, see
-            :func:`register_data` for docstring on members
-        help (str, optional): Briefly describe this family
-
-    """
-
-    _registered_families[name] = {
-        "name": name,
-        "label": label,
-        "data": data or {},
-        "help": help or "",
-        "loader": loader
-    }
-
-
-def deregister_family(name):
-    _registered_families.pop(name)
-
-
 def registered_formats():
     return _registered_formats[:]
-
-
-def registered_families():
-    return _registered_families.copy()
-
-
-def registered_data():
-    return _registered_data.copy()
 
 
 def registered_host():

--- a/mindbender/tests/test_pipeline.py
+++ b/mindbender/tests/test_pipeline.py
@@ -33,7 +33,7 @@ def setup():
     host = types.ModuleType("Test")
     host.__dict__.update({
         "ls": lambda: [],
-        "create": lambda name, family, options: None,
+        "create": lambda name, asset, family, options, data: None,
         "load": lambda asset, subset, version, representation: None,
         "update": lambda container, version: None,
         "remove": lambda container: None,

--- a/mindbender/tests/test_pipeline.py
+++ b/mindbender/tests/test_pipeline.py
@@ -20,8 +20,9 @@ self = sys.modules[__name__]
 
 
 def clear():
-    for path in pipeline.registered_loader_paths():
-        pipeline.deregister_loader_path(path)
+    for superclass, paths in pipeline.registered_plugin_paths().items():
+        for path in paths:
+            pipeline.deregister_plugin_path(superclass, path)
 
 
 def setup():
@@ -32,7 +33,7 @@ def setup():
     host = types.ModuleType("Test")
     host.__dict__.update({
         "ls": lambda: [],
-        "create": lambda name, asset, family, options: None,
+        "create": lambda name, family, options: None,
         "load": lambda asset, subset, version, representation: None,
         "update": lambda container, version: None,
         "remove": lambda container: None,
@@ -64,8 +65,8 @@ class DemoLoader(api.Loader):
         f.write(loader)
 
     try:
-        pipeline.register_loader_path(tempdir)
-        loaders = pipeline.discover_loaders()
+        pipeline.register_plugin_path(pipeline.Loader, tempdir)
+        loaders = pipeline.discover(pipeline.Loader)
 
         assert "DemoLoader" in list(
             L.__name__ for L in loaders


### PR DESCRIPTION
This PR implements #157, and here's the API for it.

```python
class Creator(object):
    name = None
    label = None
    family = None

    def __init__(self, name, asset, options=None, data=None):
        # Take into account data from user or graphical user interface
        # and establish final name and data.

    def process(self):
        # Create nodes and data in the host
```

**Simple example**

```python
from mindbender import maya

class CreateModel(maya.Creator):
    """Polygonal geometry for animation"""

    name = "modelDefault"
    label = "Model"
    family = "mindbender.model"
```

This minimal implementation is at feature parity with what is available today, via `register_family`, which is now deprecated.

Default data is coming from the superclass `__init__()` and can be overridden, such as in this more advanced example.

```python
from mindbender import maya
from maya import cmds

class CreateAnimation(maya.Creator):
    """Any character or prop animation"""

    name = "animationDefault"
    family = "mindbender.animation"
    label = "Animation"

    def __init__(self, *args, **kwargs):
        super(CreateAnimation, self).__init__(*args, **kwargs)

        self.data.update({
            "startFrame": lambda: cmds.playbackOptions(
                query=True, animationStartTime=True),
            "endFrame": lambda: cmds.playbackOptions(
                query=True, animationEndTime=True),
        })
```

`process()` is implemented once per host, and handles the actual creation of nodes within the host. It can be overridden for complex behaviour, laying the road for Creator Templates (#83).